### PR TITLE
refactor: 즐겨찾기 화면 기능 분리

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,6 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,7 +4,6 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/.idea/other.xml
+++ b/.idea/other.xml
@@ -15,6 +15,17 @@
           <option name="screenY" value="1280" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="OPPO" />
+          <option name="codename" value="OP573DL1" />
+          <option name="id" value="OP573DL1" />
+          <option name="manufacturer" value="OPPO" />
+          <option name="name" value="CPH2557" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="28" />
           <option name="brand" value="DOCOMO" />
           <option name="codename" value="SH-01L" />
@@ -116,6 +127,17 @@
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
+          <option name="codename" value="dm2q" />
+          <option name="id" value="dm2q" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="S23 Plus" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
           <option name="codename" value="dm3q" />
           <option name="id" value="dm3q" />
           <option name="manufacturer" value="Samsung" />
@@ -134,6 +156,28 @@
           <option name="screenDensity" value="480" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="e3q" />
+          <option name="id" value="e3q" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S24 Ultra" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3120" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="google" />
+          <option name="codename" value="eos" />
+          <option name="id" value="eos" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Eos" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="384" />
+          <option name="screenY" value="384" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="33" />
@@ -167,6 +211,17 @@
           <option name="screenDensity" value="420" />
           <option name="screenX" value="2208" />
           <option name="screenY" value="1840" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="fogona" />
+          <option name="id" value="fogona" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g play - 2024" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="33" />
@@ -222,6 +277,17 @@
           <option name="screenDensity" value="420" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="maui" />
+          <option name="id" value="maui" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g play - 2023" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="31" />

--- a/app/src/main/java/com/example/ssul/FavoritesFragment.kt
+++ b/app/src/main/java/com/example/ssul/FavoritesFragment.kt
@@ -12,11 +12,16 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.ssul.adapter.StoreAdapter
 import com.example.ssul.model.StoreModel
+import com.example.ssul.viewmodel.DegreeViewModel
+import com.example.ssul.viewmodel.FavoriteViewModel
+import com.example.ssul.viewmodel.FilterViewModel
+import com.example.ssul.viewmodel.StoreViewModel
 import kotlinx.coroutines.launch
 
 //class FavoritesFragment : Fragment() {
@@ -236,6 +241,21 @@ import kotlinx.coroutines.launch
 
 
 class FavoritesFragment : Fragment() {
+    // UI
+    private lateinit var degreeTextView: TextView
+    private lateinit var setDegreeButton: ImageView
+    private lateinit var storeAdapter: StoreAdapter
+    private lateinit var storeList: RecyclerView
+    private lateinit var groupFilterChip: TextView
+    private lateinit var dateFilterChip: TextView
+    private lateinit var efficiencyFilterChip: TextView
+    private lateinit var partnerFilterChip: TextView
+
+    // ViewModel
+    private lateinit var degreeViewModel: DegreeViewModel
+    private lateinit var storeViewModel: StoreViewModel
+    private lateinit var favoriteViewModel: FavoriteViewModel
+    private lateinit var filterViewModel: FilterViewModel
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -248,6 +268,99 @@ class FavoritesFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        setupViews(view)
+        setupViewModels()
+        setupAdapters()
+
+        // 가게 데이터 관찰 및 업데이트
+        storeViewModel.storeItems.observe(viewLifecycleOwner) { items ->
+            storeAdapter.updateItems(items)
+        }
+
+        // 즐겨찾기 상태 관찰 및 업데이트
+        favoriteViewModel.favoriteState.observe(viewLifecycleOwner) { favorites ->
+            storeAdapter.updateFavorites(favorites)
+        }
+
+        // 필터 상태 관찰 및 UI 업데이트
+        filterViewModel.filters.observe(viewLifecycleOwner) { filters ->
+            updateChipUI(groupFilterChip, filters.groupFilter)
+            updateChipUI(dateFilterChip, filters.dateFilter)
+            updateChipUI(efficiencyFilterChip, filters.efficiencyFilter)
+            updateChipUI(partnerFilterChip, filters.partnerFilter)
+            storeViewModel.applyFilters(filters)
+        }
+        onFilterButtonClicked()
+
+        // 학과 클릭 로직 처리 + 즐겨찾기 가게 필터링 + 즐겨찾기 토글(아이템 삭제)
     }
 
+    private fun setupViews(view: View) {
+        degreeTextView = view.findViewById(R.id.degree_text)
+        setDegreeButton = view.findViewById(R.id.set_degree_button)
+        storeList = view.findViewById(R.id.store_list)
+        storeList.layoutManager = LinearLayoutManager(requireContext())
+        groupFilterChip = view.findViewById(R.id.filter_group_button)
+        dateFilterChip = view.findViewById(R.id.filter_date_button)
+        efficiencyFilterChip = view.findViewById(R.id.filter_efficiency_button)
+        partnerFilterChip = view.findViewById(R.id.filter_partner_button)
+    }
+
+    private fun setupViewModels() {
+        degreeViewModel = ViewModelProvider(this)[DegreeViewModel::class.java]
+        storeViewModel = ViewModelProvider(this)[StoreViewModel::class.java]
+        favoriteViewModel = ViewModelProvider(this)[FavoriteViewModel::class.java]
+        filterViewModel = ViewModelProvider(this)[FilterViewModel::class.java]
+    }
+
+    private fun setupAdapters() {
+        storeAdapter = StoreAdapter(
+            storeItems = storeViewModel.storeItems.value ?: mutableListOf(),
+            favoriteItems = favoriteViewModel.favoriteState.value ?: emptyList(),
+            onFavoriteClicked = { storeId ->
+                favoriteViewModel.toggleFavorite(storeId)
+            },
+            onStoreClicked = { storeId ->
+                moveToStoreActivity(storeId)
+            }
+        )
+        storeList.adapter = storeAdapter
+    }
+
+    // 필터링 칩 UI 업데이트
+    private fun updateChipUI(chip: TextView, isSelected: Boolean) {
+        if (isSelected) {
+            chip.setBackgroundResource(R.drawable.filter_clicked)
+            chip.setTextColor(ContextCompat.getColor(requireContext(), R.color.white))
+        } else {
+            chip.setBackgroundResource(R.drawable.filter_non_clicked)
+            chip.setTextColor(ContextCompat.getColor(requireContext(), R.color.black))
+        }
+    }
+
+    // 필터 버튼 클릭 시 ViewModel에 상태 전달
+    private fun onFilterButtonClicked() {
+        groupFilterChip.setOnClickListener {
+            filterViewModel.toggleFilter("group")
+        }
+        dateFilterChip.setOnClickListener {
+            filterViewModel.toggleFilter("date")
+        }
+        efficiencyFilterChip.setOnClickListener {
+            filterViewModel.toggleFilter("efficiency")
+        }
+        partnerFilterChip.setOnClickListener {
+            filterViewModel.toggleFilter("partner")
+        }
+    }
+
+    private fun moveToStoreActivity(storeId: Int) {
+        val selectedStore = storeViewModel.storeItems.value?.find { it.id == storeId }
+
+        val intent = Intent(requireContext(), StoreActivity::class.java).apply {
+            putExtra("storeId", storeId)
+            putExtra("storeImageUrl", selectedStore?.imageUrl ?: "")
+        }
+        startActivity(intent)
+    }
 }

--- a/app/src/main/java/com/example/ssul/FavoritesFragment.kt
+++ b/app/src/main/java/com/example/ssul/FavoritesFragment.kt
@@ -272,6 +272,16 @@ class FavoritesFragment : Fragment() {
         setupViewModels()
         setupAdapters()
 
+        // 학과 정보 관찰 및 업데이트
+        degreeViewModel.selectedDepartment.observe(viewLifecycleOwner) { degree ->
+            degreeTextView.text = degree
+        }
+
+        // 학과 수정 버튼 클릭
+        setDegreeButton.setOnClickListener {
+            startActivity(Intent(requireContext(), StartActivity::class.java))
+        }
+
         // 가게 데이터 관찰 및 업데이트
         storeViewModel.storeItems.observe(viewLifecycleOwner) { items ->
             storeAdapter.updateItems(items)
@@ -322,7 +332,8 @@ class FavoritesFragment : Fragment() {
             },
             onStoreClicked = { storeId ->
                 moveToStoreActivity(storeId)
-            }
+            },
+            isFavoriteMode = true
         )
         storeList.adapter = storeAdapter
     }

--- a/app/src/main/java/com/example/ssul/FavoritesFragment.kt
+++ b/app/src/main/java/com/example/ssul/FavoritesFragment.kt
@@ -305,6 +305,11 @@ class FavoritesFragment : Fragment() {
         // 학과 클릭 로직 처리 + 즐겨찾기 가게 필터링 + 즐겨찾기 토글(아이템 삭제)
     }
 
+    override fun onResume() {
+        super.onResume()
+
+    }
+
     private fun setupViews(view: View) {
         degreeTextView = view.findViewById(R.id.degree_text)
         setDegreeButton = view.findViewById(R.id.set_degree_button)
@@ -325,7 +330,7 @@ class FavoritesFragment : Fragment() {
 
     private fun setupAdapters() {
         storeAdapter = StoreAdapter(
-            storeItems = storeViewModel.storeItems.value ?: mutableListOf(),
+            storeItems = storeViewModel.storeItems.value ?: emptyList(),
             favoriteItems = favoriteViewModel.favoriteState.value ?: emptyList(),
             onFavoriteClicked = { storeId ->
                 favoriteViewModel.toggleFavorite(storeId)

--- a/app/src/main/java/com/example/ssul/HomeFragment.kt
+++ b/app/src/main/java/com/example/ssul/HomeFragment.kt
@@ -428,11 +428,10 @@ class HomeFragment : Fragment() {
             updateChipUI(partnerFilterChip, filters.partnerFilter)
             storeViewModel.applyFilters(filters)
         }
-
         onFilterButtonClicked()
 
-        // 필터 적용
-        // 즐겨찾기 업데이트 안 됨 + 즐겨찾기 메시지 박스 안 뜸
+
+        // 즐겨찾기 업데이트 안 됨 + 즐겨찾기 메시지 박스 표시
     }
 
     private fun setupViews(view: View) {
@@ -492,8 +491,11 @@ class HomeFragment : Fragment() {
     }
 
     private fun moveToStoreActivity(storeId: Int) {
+        val selectedStore = storeViewModel.storeItems.value?.find { it.id == storeId }
+
         val intent = Intent(requireContext(), StoreActivity::class.java).apply {
             putExtra("storeId", storeId)
+            putExtra("storeImageUrl", selectedStore?.imageUrl ?: "")
         }
         startActivity(intent)
     }

--- a/app/src/main/java/com/example/ssul/HomeFragment.kt
+++ b/app/src/main/java/com/example/ssul/HomeFragment.kt
@@ -431,7 +431,7 @@ class HomeFragment : Fragment() {
         onFilterButtonClicked()
 
 
-        // 즐겨찾기 업데이트 안 됨 + 즐겨찾기 메시지 박스 표시
+        // 즐겨찾기 업데이트 + 즐겨찾기 메시지 박스 표시 + 검색 기능
     }
 
     private fun setupViews(view: View) {

--- a/app/src/main/java/com/example/ssul/HomeFragment.kt
+++ b/app/src/main/java/com/example/ssul/HomeFragment.kt
@@ -451,7 +451,7 @@ class HomeFragment : Fragment() {
 
     private fun setupAdapters() {
         storeAdapter = StoreAdapter(
-            storeItems = storeViewModel.storeItems.value ?: mutableListOf(),
+            storeItems = storeViewModel.storeItems.value ?: emptyList(),
             favoriteItems = favoriteViewModel.favoriteState.value ?: emptyList(),
             onFavoriteClicked = { storeId ->
                 favoriteViewModel.toggleFavorite(storeId)

--- a/app/src/main/java/com/example/ssul/SelectCollegeFragment.kt
+++ b/app/src/main/java/com/example/ssul/SelectCollegeFragment.kt
@@ -10,11 +10,11 @@ import android.widget.Spinner
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
-import com.example.ssul.viewmodel.DepartmentRegisterViewModel
+import com.example.ssul.viewmodel.DegreeViewModel
 
 class SelectCollegeFragment : Fragment() {
 
-    private val viewModel: DepartmentRegisterViewModel by activityViewModels()
+    private val viewModel: DegreeViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,

--- a/app/src/main/java/com/example/ssul/SelectDepartmentFragment.kt
+++ b/app/src/main/java/com/example/ssul/SelectDepartmentFragment.kt
@@ -10,11 +10,11 @@ import android.widget.ArrayAdapter
 import android.widget.Spinner
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
-import com.example.ssul.viewmodel.DepartmentRegisterViewModel
+import com.example.ssul.viewmodel.DegreeViewModel
 
 class SelectDepartmentFragment : Fragment() {
 
-    private val viewModel: DepartmentRegisterViewModel by activityViewModels()
+    private val viewModel: DegreeViewModel by activityViewModels()
 
     private val departmentMap = mapOf(
         "IT대학" to listOf(

--- a/app/src/main/java/com/example/ssul/StoreActivity.kt
+++ b/app/src/main/java/com/example/ssul/StoreActivity.kt
@@ -1,22 +1,203 @@
 package com.example.ssul
 
-import android.content.Context
-import android.content.SharedPreferences
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.example.ssul.adapter.MenuAdapter
-import kotlinx.coroutines.launch
+import com.example.ssul.model.StoreInfoModel
+import com.example.ssul.viewmodel.FavoriteViewModel
+import com.example.ssul.viewmodel.StoreViewModel
+
+//class StoreActivity : AppCompatActivity() {
+//
+//    private lateinit var storeImage: ImageView
+//    private lateinit var cancelButton: ImageView
+//    private lateinit var storeNameTextView: TextView
+//    private lateinit var filterPartnerImage: ImageView
+//    private lateinit var favoriteButton: ImageView
+//    private lateinit var locationTextView: TextView
+//    private lateinit var phoneNumberTextView: TextView
+//    private lateinit var partnershipContainer: LinearLayout
+//    private lateinit var degreeTextView: TextView
+//    private lateinit var partnerInfoTextView: TextView
+//    private lateinit var menuList: RecyclerView
+//    private lateinit var menuAdapter: MenuAdapter
+//    private lateinit var messageBox: ConstraintLayout
+//    private lateinit var messageBoxYesButton: TextView
+//    private lateinit var messageBoxNoButton: TextView
+//
+//    private lateinit var favoriteSharedPreferences: SharedPreferences
+//    private lateinit var degreeSharedPreferences: SharedPreferences
+//
+//    private lateinit var storeInfo: StoreInfo // 선택된 가게 세부 정보
+//
+//    override fun onCreate(savedInstanceState: Bundle?) {
+//        super.onCreate(savedInstanceState)
+//        setContentView(R.layout.activity_store)
+//        // 상태표시줄 색상 변경
+//        window.statusBarColor = ContextCompat.getColor(this, R.color.status_background)
+//        window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+//
+//        setupViews()
+//
+//        // 구현 사항
+//        // 1. 즐겨찾기, 학과 정보 불러오기
+//        // 2. 선택된 가게 불러오기
+//        // 3. API 요청 및 UI 업데이트
+//        // 4. 기타 버튼 동작 설정(뒤로가기, 즐겨찾기)
+//
+//
+//        // 1. 즐겨찾기, 학과 정보 불러오기
+//        favoriteSharedPreferences = this.getSharedPreferences("favorite", Context.MODE_PRIVATE)
+//        degreeSharedPreferences = this.getSharedPreferences("AppPreferences", Context.MODE_PRIVATE)
+//
+//        // 2. 선택된 가게 불러오기
+//        val storeId = intent.getIntExtra("storeId", 0)
+//        val storeImageUrl = intent.getStringExtra("storeImage")
+//
+//        // 3. API 요청 및 UI 업데이트
+//        lifecycleScope.launch {
+//            try {
+//                val college = degreeSharedPreferences.getString("selectedCollege", "")
+//                val degree = degreeSharedPreferences.getString("selectedDepartment", "")
+//
+//                // API 요청
+//                storeInfo = getStoreInfo(storeId, college!!, degree!!)
+//                storeInfo.isFavorite = favoriteSharedPreferences.getBoolean(storeInfo.id.toString(), false)
+//
+//                // UI 업데이트
+//                Glide.with(this@StoreActivity).clear(storeImage)
+//                Glide.with(this@StoreActivity)
+//                    .load(storeImageUrl)
+//                    .into(storeImage)
+//
+//                setStoreInfoContainer(storeInfo)
+//                setPartnership(storeInfo)
+//
+//                menuAdapter = MenuAdapter(storeInfo.menus)
+//                menuList.adapter = menuAdapter
+//            } catch (e: Exception) {
+//                e.printStackTrace()
+//                Toast.makeText(this@StoreActivity, "가게 정보를 불러오지 못했습니다.", Toast.LENGTH_SHORT).show()
+//                finish()
+//            }
+//        }
+//
+//        // 4. 기타 버튼 동작 설정(뒤로가기, 즐겨찾기)
+//        cancelButton.setOnClickListener {
+//            finish()
+//        }
+//
+//        favoriteButton.setOnClickListener {
+//            toggleFavorite(storeId, storeInfo)
+//        }
+//    }
+//
+//    private fun setupViews() {
+//        storeImage = findViewById(R.id.store_image)
+//        cancelButton = findViewById(R.id.cacnel_button)
+//        storeNameTextView = findViewById(R.id.store_text)
+//        filterPartnerImage = findViewById(R.id.filter_partner_image)
+//        favoriteButton = findViewById(R.id.favorite_button)
+//        locationTextView = findViewById(R.id.location_text)
+//        phoneNumberTextView = findViewById(R.id.phone_number_text)
+//        partnershipContainer = findViewById(R.id.partnership_container)
+//        degreeTextView = findViewById(R.id.degree_text)
+//        partnerInfoTextView = findViewById(R.id.partner_info_text)
+//        menuList = findViewById(R.id.menu_list)
+//        menuList.layoutManager = LinearLayoutManager(this)
+//
+//        messageBox = findViewById(R.id.message_box)
+//        messageBoxYesButton = findViewById(R.id.message_box_yes_button)
+//        messageBoxNoButton = findViewById(R.id.message_box_no_button)
+//    }
+//
+//    // 가게 정보 컨테이너 세팅 함수
+//    private fun setStoreInfoContainer(currentStore: StoreInfo) {
+//        storeNameTextView.text = currentStore.name
+//        locationTextView.text = currentStore.address
+//        phoneNumberTextView.text = currentStore.contact
+//
+//        // 제휴 마크 표시
+//        if (currentStore.isAssociated) {
+//            filterPartnerImage.visibility = View.VISIBLE
+//        } else {
+//            filterPartnerImage.visibility = View.GONE
+//        }
+//
+//        // 즐겨찾기 표시
+//        if (currentStore.isFavorite) {
+//            favoriteButton.setImageResource(R.drawable.favorite_clicked)
+//        } else {
+//            favoriteButton.setImageResource(R.drawable.favorite_non_clicked)
+//        }
+//    }
+//
+//    // 즐겨 찾기 토글 함수
+//    private fun toggleFavorite(storeId: Int, currentStore: StoreInfo) {
+//        if (currentStore.isFavorite) {
+//            showMessageBox(storeId, currentStore)
+//        } else {
+//            updateFavoriteState(storeId, currentStore)
+//        }
+//    }
+//
+//    // 즐겨 찾기 제거 시 띄울 메시지 박스 함수
+//    private fun showMessageBox(storeId: Int, currentStore: StoreInfo) {
+//        messageBox.visibility = View.VISIBLE
+//
+//        // Yes 버튼 클릭 시 상태 변경
+//        messageBoxYesButton.setOnClickListener {
+//            updateFavoriteState(storeId, currentStore)
+//            messageBox.visibility = View.GONE
+//        }
+//
+//        messageBoxNoButton.setOnClickListener {
+//            messageBox.visibility = View.GONE
+//        }
+//    }
+//
+//    // 즐겨 찾기 상태 변경 함수
+//    private fun updateFavoriteState(storeId: Int, currentStore: StoreInfo) {
+//        // 즐겨찾기 상태 변경
+//        currentStore.isFavorite = !currentStore.isFavorite
+//
+//        // 내부 저장소 업데이트
+//        with(favoriteSharedPreferences.edit()) {
+//            putBoolean(storeId.toString(), currentStore.isFavorite)
+//            apply()
+//        }
+//
+//        // UI 갱신
+//        setStoreInfoContainer(currentStore)
+//    }
+//
+//    // 제휴 정보 설정 함수
+//    private fun setPartnership(store: StoreInfo) {
+//        if (store.isAssociated) {
+//            partnershipContainer.visibility = View.VISIBLE
+//            degreeTextView.text = store.associationInfo.first
+//            partnerInfoTextView.text = store.associationInfo.second
+//        } else {
+//            partnershipContainer.visibility = View.GONE
+//        }
+//    }
+//
+//}
+
+
+
+
 
 class StoreActivity : AppCompatActivity() {
 
@@ -36,10 +217,11 @@ class StoreActivity : AppCompatActivity() {
     private lateinit var messageBoxYesButton: TextView
     private lateinit var messageBoxNoButton: TextView
 
-    private lateinit var favoriteSharedPreferences: SharedPreferences
-    private lateinit var degreeSharedPreferences: SharedPreferences
+    private lateinit var storeViewModel: StoreViewModel
+    private lateinit var favoriteViewModel: FavoriteViewModel
 
-    private lateinit var storeInfo: StoreInfo // 선택된 가게 세부 정보
+    private var storeId: Int = 0
+    private var storeImageUrl: String = ""
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -48,59 +230,27 @@ class StoreActivity : AppCompatActivity() {
         window.statusBarColor = ContextCompat.getColor(this, R.color.status_background)
         window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
 
+        storeId = intent.getIntExtra("storeId", 0)
+        storeImageUrl = intent.getStringExtra("storeImageUrl") ?: ""
+
         setupViews()
+        setupViewModels()
 
-        // 구현 사항
-        // 1. 즐겨찾기, 학과 정보 불러오기
-        // 2. 선택된 가게 불러오기
-        // 3. API 요청 및 UI 업데이트
-        // 4. 기타 버튼 동작 설정(뒤로가기, 즐겨찾기)
-
-
-        // 1. 즐겨찾기, 학과 정보 불러오기
-        favoriteSharedPreferences = this.getSharedPreferences("favorite", Context.MODE_PRIVATE)
-        degreeSharedPreferences = this.getSharedPreferences("AppPreferences", Context.MODE_PRIVATE)
-
-        // 2. 선택된 가게 불러오기
-        val storeId = intent.getIntExtra("storeId", 0)
-        val storeImageUrl = intent.getStringExtra("storeImage")
-
-        // 3. API 요청 및 UI 업데이트
-        lifecycleScope.launch {
-            try {
-                val college = degreeSharedPreferences.getString("selectedCollege", "")
-                val degree = degreeSharedPreferences.getString("selectedDepartment", "")
-
-                // API 요청
-                storeInfo = getStoreInfo(storeId, college!!, degree!!)
-                storeInfo.isFavorite = favoriteSharedPreferences.getBoolean(storeInfo.id.toString(), false)
-
-                // UI 업데이트
-                Glide.with(this@StoreActivity).clear(storeImage)
-                Glide.with(this@StoreActivity)
-                    .load(storeImageUrl)
-                    .into(storeImage)
-
-                setStoreInfoContainer(storeInfo)
-                setPartnership(storeInfo)
-
-                menuAdapter = MenuAdapter(storeInfo.menus)
-                menuList.adapter = menuAdapter
-            } catch (e: Exception) {
-                e.printStackTrace()
-                Toast.makeText(this@StoreActivity, "가게 정보를 불러오지 못했습니다.", Toast.LENGTH_SHORT).show()
-                finish()
-            }
+        // 가게 정보 상태 관찰 및 업데이트
+        storeViewModel.loadStoreInfo(storeId)
+        storeViewModel.storeInfo.observe(this) { storeInfo ->
+            storeInfo?.let { updateStoreInfoUI(it, storeImageUrl) }
         }
 
-        // 4. 기타 버튼 동작 설정(뒤로가기, 즐겨찾기)
-        cancelButton.setOnClickListener {
-            finish()
+        // 즐겨찾기 상태 관찰 및 업데이트
+        favoriteViewModel.favoriteState.observe(this) { favorites ->
+            val isFavorite = favorites.any { it.storeId == storeId && it.isFavorite }
+            updateFavoriteUI(isFavorite)
         }
-
         favoriteButton.setOnClickListener {
-            toggleFavorite(storeId, storeInfo)
+            favoriteViewModel.toggleFavorite(storeId)
         }
+
     }
 
     private fun setupViews() {
@@ -122,75 +272,39 @@ class StoreActivity : AppCompatActivity() {
         messageBoxNoButton = findViewById(R.id.message_box_no_button)
     }
 
-    // 가게 정보 컨테이너 세팅 함수
-    private fun setStoreInfoContainer(currentStore: StoreInfo) {
-        storeNameTextView.text = currentStore.name
-        locationTextView.text = currentStore.address
-        phoneNumberTextView.text = currentStore.contact
+    private fun setupViewModels() {
+        storeViewModel = ViewModelProvider(this)[StoreViewModel::class]
+        favoriteViewModel = ViewModelProvider(this)[FavoriteViewModel::class]
+    }
 
-        // 제휴 마크 표시
-        if (currentStore.isAssociated) {
-            filterPartnerImage.visibility = View.VISIBLE
+    // UI 업데이트
+    private fun updateStoreInfoUI(storeInfo: StoreInfoModel, storeImageUrl: String) {
+        Glide.with(this)
+            .load(storeImageUrl)
+            .placeholder(R.drawable.default_image)
+            .error(R.drawable.default_image)
+            .into(storeImage)
+
+        storeNameTextView.text = storeInfo.name
+        locationTextView.text = storeInfo.address
+        phoneNumberTextView.text = storeInfo.contact
+
+        if (storeInfo.isAssociated) {
+            partnershipContainer.visibility = View.VISIBLE
+            degreeTextView.text = storeInfo.associationInfo.first
+            partnerInfoTextView.text = storeInfo.associationInfo.second
         } else {
             filterPartnerImage.visibility = View.GONE
-        }
-
-        // 즐겨찾기 표시
-        if (currentStore.isFavorite) {
-            favoriteButton.setImageResource(R.drawable.favorite_clicked)
-        } else {
-            favoriteButton.setImageResource(R.drawable.favorite_non_clicked)
-        }
-    }
-
-    // 즐겨 찾기 토글 함수
-    private fun toggleFavorite(storeId: Int, currentStore: StoreInfo) {
-        if (currentStore.isFavorite) {
-            showMessageBox(storeId, currentStore)
-        } else {
-            updateFavoriteState(storeId, currentStore)
-        }
-    }
-
-    // 즐겨 찾기 제거 시 띄울 메시지 박스 함수
-    private fun showMessageBox(storeId: Int, currentStore: StoreInfo) {
-        messageBox.visibility = View.VISIBLE
-
-        // Yes 버튼 클릭 시 상태 변경
-        messageBoxYesButton.setOnClickListener {
-            updateFavoriteState(storeId, currentStore)
-            messageBox.visibility = View.GONE
-        }
-
-        messageBoxNoButton.setOnClickListener {
-            messageBox.visibility = View.GONE
-        }
-    }
-
-    // 즐겨 찾기 상태 변경 함수
-    private fun updateFavoriteState(storeId: Int, currentStore: StoreInfo) {
-        // 즐겨찾기 상태 변경
-        currentStore.isFavorite = !currentStore.isFavorite
-
-        // 내부 저장소 업데이트
-        with(favoriteSharedPreferences.edit()) {
-            putBoolean(storeId.toString(), currentStore.isFavorite)
-            apply()
-        }
-
-        // UI 갱신
-        setStoreInfoContainer(currentStore)
-    }
-
-    // 제휴 정보 설정 함수
-    private fun setPartnership(store: StoreInfo) {
-        if (store.isAssociated) {
-            partnershipContainer.visibility = View.VISIBLE
-            degreeTextView.text = store.associationInfo.first
-            partnerInfoTextView.text = store.associationInfo.second
-        } else {
             partnershipContainer.visibility = View.GONE
         }
+
+        menuAdapter = MenuAdapter(storeInfo.menus)
+        menuList.adapter = menuAdapter
     }
 
+    private fun updateFavoriteUI(isFavorite: Boolean) {
+        favoriteButton.setImageResource(
+            if (isFavorite) R.drawable.favorite_clicked else R.drawable.favorite_non_clicked
+        )
+    }
 }

--- a/app/src/main/java/com/example/ssul/WelcomeFragment.kt
+++ b/app/src/main/java/com/example/ssul/WelcomeFragment.kt
@@ -10,11 +10,11 @@ import android.widget.Button
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import com.example.ssul.viewmodel.DepartmentRegisterViewModel
+import com.example.ssul.viewmodel.DegreeViewModel
 
 class WelcomeFragment : Fragment() {
 
-    private val viewModel: DepartmentRegisterViewModel by activityViewModels()
+    private val viewModel: DegreeViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,

--- a/app/src/main/java/com/example/ssul/adapter/MenuAdapter.kt
+++ b/app/src/main/java/com/example/ssul/adapter/MenuAdapter.kt
@@ -8,9 +8,9 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.example.ssul.R
-import com.example.ssul.StoreInfo
+import com.example.ssul.model.StoreInfoModel
 
-class MenuAdapter(private val menuList: List<StoreInfo.MenuItem>) :
+class MenuAdapter(private val menuList: List<StoreInfoModel.MenuItem>) :
     RecyclerView.Adapter<MenuAdapter.MenuViewHolder>() {
 
     inner class MenuViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {

--- a/app/src/main/java/com/example/ssul/adapter/StoreAdapter.kt
+++ b/app/src/main/java/com/example/ssul/adapter/StoreAdapter.kt
@@ -17,7 +17,8 @@ class StoreAdapter(
     private var storeItems: MutableList<StoreModel>,
     private var favoriteItems: List<FavoriteModel>,
     private val onFavoriteClicked: (Int) -> Unit,
-    private val onStoreClicked: (Int) -> Unit
+    private val onStoreClicked: (Int) -> Unit,
+    private val isFavoriteMode: Boolean = false
 ) : RecyclerView.Adapter<StoreAdapter.StoreViewHolder>() {
 
     inner class StoreViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
@@ -100,13 +101,24 @@ class StoreAdapter(
 
     // 가게 리스트 업데이트
     fun updateItems(newItems: List<StoreModel>) {
-        storeItems = newItems.toMutableList()
+        storeItems = if (isFavoriteMode) { // FavoriteFragment
+            newItems.filter { store ->
+                favoriteItems.any { favorite -> favorite.storeId == store.id && favorite.isFavorite }
+            }.toMutableList()
+        } else { // HomeFragment
+            newItems.toMutableList()
+        }
         notifyDataSetChanged()
     }
 
     // 즐겨찾기 상태 업데이트
     fun updateFavorites(favorites: List<FavoriteModel>) {
         favoriteItems = favorites
+        if (isFavoriteMode) { // FavoriteFragment
+            storeItems = storeItems.filter { store ->
+                favoriteItems.any { favorite -> favorite.storeId == store.id && favorite.isFavorite }
+            }.toMutableList()
+        }
         notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/com/example/ssul/adapter/StoreAdapter.kt
+++ b/app/src/main/java/com/example/ssul/adapter/StoreAdapter.kt
@@ -14,7 +14,7 @@ import com.example.ssul.model.FavoriteModel
 import com.example.ssul.model.StoreModel
 
 class StoreAdapter(
-    private var storeItems: MutableList<StoreModel>,
+    private var storeItems: List<StoreModel>,
     private var favoriteItems: List<FavoriteModel>,
     private val onFavoriteClicked: (Int) -> Unit,
     private val onStoreClicked: (Int) -> Unit,
@@ -42,12 +42,10 @@ class StoreAdapter(
             storeText.text = item.name
             locationText.text = item.address
 
-            // 즐겨찾기 상태 조회
-            val isFavorite = favoriteItems.any { it.storeId == item.id && it.isFavorite }
 
             // 즐겨찾기 가시성 조정
             favoriteButton.setImageResource(
-                if (isFavorite) R.drawable.favorite_clicked else R.drawable.favorite_non_clicked
+                if (item.isFavorite) R.drawable.favorite_clicked else R.drawable.favorite_non_clicked
             )
 
             // 즐겨찾기 클릭 처리
@@ -101,12 +99,9 @@ class StoreAdapter(
 
     // 가게 리스트 업데이트
     fun updateItems(newItems: List<StoreModel>) {
-        storeItems = if (isFavoriteMode) { // FavoriteFragment
-            newItems.filter { store ->
-                favoriteItems.any { favorite -> favorite.storeId == store.id && favorite.isFavorite }
-            }.toMutableList()
-        } else { // HomeFragment
-            newItems.toMutableList()
+        storeItems = applyFavoritesToItems(newItems, favoriteItems)
+        if (isFavoriteMode) { // FavoriteFragment
+            storeItems = storeItems.filter { it.isFavorite }
         }
         notifyDataSetChanged()
     }
@@ -114,11 +109,16 @@ class StoreAdapter(
     // 즐겨찾기 상태 업데이트
     fun updateFavorites(favorites: List<FavoriteModel>) {
         favoriteItems = favorites
+        storeItems = applyFavoritesToItems(storeItems, favoriteItems)
         if (isFavoriteMode) { // FavoriteFragment
-            storeItems = storeItems.filter { store ->
-                favoriteItems.any { favorite -> favorite.storeId == store.id && favorite.isFavorite }
-            }.toMutableList()
+            storeItems = storeItems.filter { it.isFavorite }
         }
         notifyDataSetChanged()
+    }
+
+    private fun applyFavoritesToItems(storeItems: List<StoreModel>, favoriteItems: List<FavoriteModel>): List<StoreModel> {
+        return storeItems.map { store ->
+            store.copy(isFavorite = favoriteItems.any { favorite -> favorite.storeId == store.id && favorite.isFavorite })
+        }
     }
 }

--- a/app/src/main/java/com/example/ssul/api/ApiData.kt
+++ b/app/src/main/java/com/example/ssul/api/ApiData.kt
@@ -18,6 +18,7 @@ data class StoreInfoResponse(
     val isAssociated: Boolean,
     val address: String,
     val contact: String?,
+    val imageUrl: String,
     val associationInfo: AssociationInfo?,
     val menus: List<MenuResponse>
 ) {

--- a/app/src/main/java/com/example/ssul/model/StoreModel.kt
+++ b/app/src/main/java/com/example/ssul/model/StoreModel.kt
@@ -3,10 +3,26 @@ package com.example.ssul.model
 data class StoreModel(
     val id: Int,                                // Store ID
     val name: String,                           // Store 이름
-    var address: String = "정보 없음",           // 위치 텍스트
+    val address: String,                        // 위치 텍스트
     val isFilterGroupChecked: Boolean,          // group 필터 선택 여부
     val isFilterDateChecked: Boolean,           // date 필터 선택 여부
     val isFilterEfficiencyChecked: Boolean,     // efficiency 필터 선택 여부
-    var imageUrl: String = "",                  // Store 이미지 리소스 ID
+    val imageUrl: String,                       // Store 이미지 리소스 ID
     val isAssociated: Boolean                   // partner 필터 선택 여부
 )
+
+data class StoreInfoModel(
+    val id: Int,
+    val name: String,
+    val isAssociated: Boolean,
+    val address: String,
+    val contact: String,
+    val associationInfo: Pair<String, String>,  // 제휴 정보
+    val menus: List<MenuItem>
+) {
+    data class MenuItem(
+        val name: String,
+        val price: String,
+        val imageUrl: String
+    )
+}

--- a/app/src/main/java/com/example/ssul/model/StoreModel.kt
+++ b/app/src/main/java/com/example/ssul/model/StoreModel.kt
@@ -8,7 +8,8 @@ data class StoreModel(
     val isFilterDateChecked: Boolean,           // date 필터 선택 여부
     val isFilterEfficiencyChecked: Boolean,     // efficiency 필터 선택 여부
     val imageUrl: String,                       // Store 이미지 리소스 ID
-    val isAssociated: Boolean                   // partner 필터 선택 여부
+    val isAssociated: Boolean,                  // partner 필터 선택 여부
+    val isFavorite: Boolean = false
 )
 
 data class StoreInfoModel(

--- a/app/src/main/java/com/example/ssul/repository/StoreRepository.kt
+++ b/app/src/main/java/com/example/ssul/repository/StoreRepository.kt
@@ -1,8 +1,10 @@
 package com.example.ssul.repository
 
+import android.util.Log
 import com.example.ssul.api.RetrofitClient
 import com.example.ssul.api.collegeCodeMap
 import com.example.ssul.api.degreeCodeMap
+import com.example.ssul.model.StoreInfoModel
 import com.example.ssul.model.StoreModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -17,6 +19,7 @@ class StoreRepository {
                 val response = RetrofitClient.apiService.getStores(collegeCode, degreeCode).execute()
                 if (response.isSuccessful) {
                     val storeResponses = response.body() ?: emptyList()
+
                     storeResponses.map { storeResponse ->
                         StoreModel(
                             id = storeResponse.id,
@@ -35,6 +38,56 @@ class StoreRepository {
             } catch (e: Exception) {
                 e.printStackTrace()
                 mutableListOf()
+            }
+        }
+    }
+}
+
+class StoreInfoRepository {
+    suspend fun getStoreInfo(storeId: Int, college: String, degree: String): StoreInfoModel {
+        return withContext(Dispatchers.IO) {
+            try {
+                val collegeCode = collegeCodeMap[college] ?: throw IllegalArgumentException("Unknown college name: $college")
+                val degreeCode = degreeCodeMap[degree] ?: throw IllegalArgumentException("Unknown degree name: $degree")
+
+                val response = RetrofitClient.apiService.getStoreInfo(storeId, collegeCode, degreeCode).execute()
+                if (response.isSuccessful) {
+                    val storeResponse = response.body() ?: throw java.lang.IllegalArgumentException("Invalid Store Response")
+                    val associationTarget = collegeCodeMap.entries.find { it.value == storeResponse.associationInfo?.target }?.key
+                        ?: degreeCodeMap.entries.find { it.value == storeResponse.associationInfo?.target }?.key
+                        ?: "정보 없음"
+
+                    Log.d("StoreInfo", "API Response: $storeResponse")
+
+                    StoreInfoModel(
+                        id = storeResponse.id,
+                        name = storeResponse.name,
+                        isAssociated = storeResponse.isAssociated,
+                        address = storeResponse.address,
+                        contact = storeResponse.contact ?: "정보 없음",
+                        associationInfo = associationTarget to (storeResponse.associationInfo?.description ?: "정보 없음"),
+                        menus = storeResponse.menus.map { menu ->
+                            StoreInfoModel.MenuItem(
+                                name = menu.name,
+                                price = menu.price,
+                                imageUrl = menu.imageUrl ?: ""
+                            )
+                        }
+                    )
+                } else {
+                    throw IllegalArgumentException("Failed to fetch store info: ${response.errorBody()?.string()}")
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                StoreInfoModel(
+                    id = 0,
+                    name = "",
+                    isAssociated = false,
+                    address = "정보 없음",
+                    contact = "정보 없음",
+                    associationInfo = "정보 없음" to "정보 없음",
+                    menus = emptyList()
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/ssul/repository/StoreRepository.kt
+++ b/app/src/main/java/com/example/ssul/repository/StoreRepository.kt
@@ -1,6 +1,5 @@
 package com.example.ssul.repository
 
-import android.util.Log
 import com.example.ssul.api.RetrofitClient
 import com.example.ssul.api.collegeCodeMap
 import com.example.ssul.api.degreeCodeMap
@@ -10,16 +9,17 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class StoreRepository {
-    suspend fun getStores(college: String, degree: String): MutableList<StoreModel> {
-        return withContext(Dispatchers.IO) {
-            try {
-                val collegeCode = collegeCodeMap[college] ?: throw IllegalArgumentException("Unknown college name: $college")
-                val degreeCode = degreeCodeMap[degree] ?: throw IllegalArgumentException("Unknown degree name: $degree")
+    suspend fun getStores(college: String, degree: String): Result<MutableList<StoreModel>> =
+        withContext(Dispatchers.IO) {
+            val collegeCode = collegeCodeMap[college]
+                ?: return@withContext Result.failure(IllegalArgumentException("Unknown college name: $college"))
+            val degreeCode = degreeCodeMap[degree]
+                ?: return@withContext Result.failure(IllegalArgumentException("Unknown degree name: $degree"))
 
+            runCatching {
                 val response = RetrofitClient.apiService.getStores(collegeCode, degreeCode).execute()
                 if (response.isSuccessful) {
                     val storeResponses = response.body() ?: emptyList()
-
                     storeResponses.map { storeResponse ->
                         StoreModel(
                             id = storeResponse.id,
@@ -33,31 +33,25 @@ class StoreRepository {
                         )
                     }.toMutableList()
                 } else {
-                    mutableListOf()
+                    throw Exception("Failed to fetch stores: ${response.errorBody()?.string()}")
                 }
-            } catch (e: Exception) {
-                e.printStackTrace()
-                mutableListOf()
             }
         }
-    }
-}
 
-class StoreInfoRepository {
-    suspend fun getStoreInfo(storeId: Int, college: String, degree: String): StoreInfoModel {
-        return withContext(Dispatchers.IO) {
-            try {
-                val collegeCode = collegeCodeMap[college] ?: throw IllegalArgumentException("Unknown college name: $college")
-                val degreeCode = degreeCodeMap[degree] ?: throw IllegalArgumentException("Unknown degree name: $degree")
+    suspend fun getStoreInfo(storeId: Int, college: String, degree: String): Result<StoreInfoModel> =
+        withContext(Dispatchers.IO) {
+            val collegeCode = collegeCodeMap[college]
+                ?: return@withContext Result.failure(IllegalArgumentException("Unknown college name: $college"))
+            val degreeCode = degreeCodeMap[degree]
+                ?: return@withContext Result.failure(IllegalArgumentException("Unknown degree name: $degree"))
 
+            runCatching {
                 val response = RetrofitClient.apiService.getStoreInfo(storeId, collegeCode, degreeCode).execute()
                 if (response.isSuccessful) {
-                    val storeResponse = response.body() ?: throw java.lang.IllegalArgumentException("Invalid Store Response")
+                    val storeResponse = response.body() ?: throw IllegalArgumentException("Invalid Store Response")
                     val associationTarget = collegeCodeMap.entries.find { it.value == storeResponse.associationInfo?.target }?.key
                         ?: degreeCodeMap.entries.find { it.value == storeResponse.associationInfo?.target }?.key
                         ?: "정보 없음"
-
-                    Log.d("StoreInfo", "API Response: $storeResponse")
 
                     StoreInfoModel(
                         id = storeResponse.id,
@@ -77,18 +71,6 @@ class StoreInfoRepository {
                 } else {
                     throw IllegalArgumentException("Failed to fetch store info: ${response.errorBody()?.string()}")
                 }
-            } catch (e: Exception) {
-                e.printStackTrace()
-                StoreInfoModel(
-                    id = 0,
-                    name = "",
-                    isAssociated = false,
-                    address = "정보 없음",
-                    contact = "정보 없음",
-                    associationInfo = "정보 없음" to "정보 없음",
-                    menus = emptyList()
-                )
             }
         }
-    }
 }

--- a/app/src/main/java/com/example/ssul/viewmodel/DegreeViewModel.kt
+++ b/app/src/main/java/com/example/ssul/viewmodel/DegreeViewModel.kt
@@ -1,15 +1,25 @@
 package com.example.ssul.viewmodel
 
+import android.app.Application
+import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 
-class DepartmentRegisterViewModel : ViewModel() {
+class DegreeViewModel : ViewModel() {
     private val _selectedCollege = MutableLiveData<String>()
     val selectedCollege: LiveData<String> get() = _selectedCollege
 
     private val _selectedDepartment = MutableLiveData<String>()
     val selectedDepartment: LiveData<String> get() = _selectedDepartment
+
+    init {
+        loadCollegeInfo()
+    }
+
+    private fun loadCollegeInfo() {
+
+    }
 
     fun setCollege(college: String) {
         _selectedCollege.value = college

--- a/app/src/main/java/com/example/ssul/viewmodel/DegreeViewModel.kt
+++ b/app/src/main/java/com/example/ssul/viewmodel/DegreeViewModel.kt
@@ -2,11 +2,11 @@ package com.example.ssul.viewmodel
 
 import android.app.Application
 import android.content.Context
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
 
-class DegreeViewModel : ViewModel() {
+class DegreeViewModel(application: Application) : AndroidViewModel(application) {
     private val _selectedCollege = MutableLiveData<String>()
     val selectedCollege: LiveData<String> get() = _selectedCollege
 
@@ -18,7 +18,9 @@ class DegreeViewModel : ViewModel() {
     }
 
     private fun loadCollegeInfo() {
-
+        val prefs = getApplication<Application>().getSharedPreferences("AppPreferences", Context.MODE_PRIVATE)
+        _selectedCollege.value = prefs.getString("selectedCollege", "") ?: ""
+        _selectedDepartment.value = prefs.getString("selectedDepartment", "") ?: ""
     }
 
     fun setCollege(college: String) {

--- a/app/src/main/java/com/example/ssul/viewmodel/FavoriteViewModel.kt
+++ b/app/src/main/java/com/example/ssul/viewmodel/FavoriteViewModel.kt
@@ -32,7 +32,7 @@ class FavoriteViewModel(application: Application) : AndroidViewModel(application
     fun toggleFavorite(storeId: Int) {
         val currentList = _favoriteState.value?.toMutableList() ?: mutableListOf()
 
-        val selectedItem = currentList.find { it.storeId == storeId }
+        val selectedItem: FavoriteModel? = currentList.find { it.storeId == storeId }
         if (selectedItem != null) {
             selectedItem.isFavorite = !selectedItem.isFavorite
         } else {

--- a/app/src/main/java/com/example/ssul/viewmodel/StoreViewModel.kt
+++ b/app/src/main/java/com/example/ssul/viewmodel/StoreViewModel.kt
@@ -7,17 +7,23 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.example.ssul.model.FilterModel
+import com.example.ssul.model.StoreInfoModel
 import com.example.ssul.model.StoreModel
+import com.example.ssul.repository.StoreInfoRepository
 import com.example.ssul.repository.StoreRepository
 import kotlinx.coroutines.launch
 
 class StoreViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val repository = StoreRepository()
+    private val storeRepository = StoreRepository()
+    private val storeInfoRepository = StoreInfoRepository()
     private val _allStores = MutableLiveData<MutableList<StoreModel>>()
     private val _filteredStores = MutableLiveData<MutableList<StoreModel>>()
     val storeItems: LiveData<MutableList<StoreModel>> get() = _filteredStores
     // FavoriteFragment 위해 즐겨찾기 아이템 추가? var favStoreItems
+
+    private val _storeInfo = MutableLiveData<StoreInfoModel>()
+    val storeInfo: LiveData<StoreInfoModel> get() = _storeInfo
 
     private var college: String = ""
     private var degree: String = ""
@@ -37,9 +43,17 @@ class StoreViewModel(application: Application) : AndroidViewModel(application) {
     // 가게 데이터 불러오기
     private fun loadStores() {
         viewModelScope.launch {
-            val stores = repository.getStores(college, degree)
+            val stores = storeRepository.getStores(college, degree)
             _allStores.value = stores
             _filteredStores.value = stores
+        }
+    }
+
+    // 가게 세부 데이터 불러오기
+    fun loadStoreInfo(storeId: Int) {
+        viewModelScope.launch {
+            val storeInfo = storeInfoRepository.getStoreInfo(storeId, college, degree)
+            _storeInfo.value = storeInfo
         }
     }
 

--- a/app/src/main/java/com/example/ssul/viewmodel/StoreViewModel.kt
+++ b/app/src/main/java/com/example/ssul/viewmodel/StoreViewModel.kt
@@ -20,7 +20,6 @@ class StoreViewModel(application: Application) : AndroidViewModel(application) {
     private val _allStores = MutableLiveData<MutableList<StoreModel>>()
     private val _filteredStores = MutableLiveData<MutableList<StoreModel>>()
     val storeItems: LiveData<MutableList<StoreModel>> get() = _filteredStores
-    // FavoriteFragment 위해 즐겨찾기 아이템 추가? var favStoreItems
 
     private val _storeInfo = MutableLiveData<StoreInfoModel>()
     val storeInfo: LiveData<StoreInfoModel> get() = _storeInfo

--- a/app/src/main/java/com/example/ssul/viewmodel/StoreViewModel.kt
+++ b/app/src/main/java/com/example/ssul/viewmodel/StoreViewModel.kt
@@ -9,14 +9,12 @@ import androidx.lifecycle.viewModelScope
 import com.example.ssul.model.FilterModel
 import com.example.ssul.model.StoreInfoModel
 import com.example.ssul.model.StoreModel
-import com.example.ssul.repository.StoreInfoRepository
 import com.example.ssul.repository.StoreRepository
 import kotlinx.coroutines.launch
 
 class StoreViewModel(application: Application) : AndroidViewModel(application) {
 
     private val storeRepository = StoreRepository()
-    private val storeInfoRepository = StoreInfoRepository()
     private val _allStores = MutableLiveData<MutableList<StoreModel>>()
     private val _filteredStores = MutableLiveData<MutableList<StoreModel>>()
     val storeItems: LiveData<MutableList<StoreModel>> get() = _filteredStores
@@ -42,17 +40,29 @@ class StoreViewModel(application: Application) : AndroidViewModel(application) {
     // 가게 데이터 불러오기
     private fun loadStores() {
         viewModelScope.launch {
-            val stores = storeRepository.getStores(college, degree)
-            _allStores.value = stores
-            _filteredStores.value = stores
+            storeRepository.getStores(college, degree)
+                .onSuccess { stores ->
+                    _allStores.value = stores
+                    _filteredStores.value = stores
+                }
+                .onFailure { error ->
+                    error.printStackTrace()
+                    _allStores.value = mutableListOf()
+                    _filteredStores.value = mutableListOf()
+                }
         }
     }
 
     // 가게 세부 데이터 불러오기
     fun loadStoreInfo(storeId: Int) {
         viewModelScope.launch {
-            val storeInfo = storeInfoRepository.getStoreInfo(storeId, college, degree)
-            _storeInfo.value = storeInfo
+            storeRepository.getStoreInfo(storeId, college, degree)
+                .onSuccess { info ->
+                    _storeInfo.value = info
+                }
+                .onFailure { error ->
+                    error.printStackTrace()
+                }
         }
     }
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -29,7 +29,7 @@
                 android:id="@+id/search_back_button"
                 android:layout_width="25dp"
                 android:layout_height="25dp"
-                android:layout_marginRight="16dp"
+                android:layout_marginEnd="16dp"
                 android:src="@drawable/ic_back"
                 android:visibility="gone"/>
 


### PR DESCRIPTION
## Summary
- 즐겨찾기 화면(FavoritesFragment)의기능 분리, MVVM 적용 


## Describe your changes
- DegreeViewModel : FavoritesFragment에서 학과 정보를 옵저빙하기 위해, 해당 뷰모델에서 학교 정보와 학과 정보 관리
- FavoritesFragment : 학과 정보 수정 기능, 즐겨찾기 추가된 가게 표시 기능, 필터 기능 분리


## To reviewers
- 발생한 문제 : 다른 프래그먼트 혹은 액티비티에서 즐겨찾기 상태 수정 후, 현재 프래그먼트의 즐겨찾기 ui가 바로 반영되지 않는 문제 발생(HomeFragment와 FavoritesFragment 해결 필요)